### PR TITLE
Handle improperly encoded inputs

### DIFF
--- a/can-deparam-test.js
+++ b/can-deparam-test.js
@@ -36,6 +36,10 @@ test('Remaining ampersand', function () {
 		}
 	});
 });
+test('Invalid encoding', function() {
+	deparam('foo=%0g');
+	ok(true, 'Did not throw');
+})
 /** /
 test("deparam an array", function(){
 var data = deparam("a[0]=1&a[1]=2");

--- a/can-deparam-test.js
+++ b/can-deparam-test.js
@@ -37,9 +37,11 @@ test('Remaining ampersand', function () {
 	});
 });
 test('Invalid encoding', function() {
-	deparam('foo=%0g');
-	ok(true, 'Did not throw');
-})
+	var data = deparam('foo=%0g');
+	deepEqual(data, {
+		foo: '%0g'
+	});
+});
 /** /
 test("deparam an array", function(){
 var data = deparam("a[0]=1&a[1]=2");

--- a/can-deparam.js
+++ b/can-deparam.js
@@ -22,7 +22,21 @@ var digitTest = /^\d+$/,
 	keyBreaker = /([^\[\]]+)|(\[\])/g,
 	paramTest = /([^?#]*)(#.*)?$/,
 	prep = function (str) {
-		return decodeURIComponent(str.replace(/\+/g, ' '));
+		str = str.replace(/\+/g, ' ');
+
+		try {
+			return decodeURIComponent(str);
+		}
+		catch (e) {
+			return str.replace(/%(.{2})/, function(match, hex) {
+				try {
+					return decodeURIComponent(match);
+				}
+				catch (e) {
+					return match;
+				}
+			});
+		}
 	};
 module.exports = namespace.deparam = function (params) {
 	var data = {}, pairs, lastPart;

--- a/can-deparam.js
+++ b/can-deparam.js
@@ -21,6 +21,7 @@ var namespace = require("can-namespace");
 var digitTest = /^\d+$/,
 	keyBreaker = /([^\[\]]+)|(\[\])/g,
 	paramTest = /([^?#]*)(#.*)?$/,
+	entityRegex = /%([^0-9a-f][0-9a-f]|[0-9a-f][^0-9a-f]|[^0-9a-f][^0-9a-f])/i,
 	prep = function (str) {
 		str = str.replace(/\+/g, ' ');
 
@@ -28,14 +29,9 @@ var digitTest = /^\d+$/,
 			return decodeURIComponent(str);
 		}
 		catch (e) {
-			return str.replace(/%(.{2})/, function(match, hex) {
-				try {
-					return decodeURIComponent(match);
-				}
-				catch (e) {
-					return match;
-				}
-			});
+			return decodeURIComponent(str.replace(entityRegex, function(match, hex) {
+				return '%25' + hex;
+			}));
 		}
 	};
 module.exports = namespace.deparam = function (params) {


### PR DESCRIPTION
Update to allow improperly encoded inputs, such as `foo=&0g`. A [quick perf test](https://gist.github.com/christopherjbaker/b21fbb0266f255ac5ed301855be9ca2d) showed minimal impact (1-2%) for non-failing cases.

On a failing input, I am individually finding all entities. For each entity, I attempt to decode it, then return the normal string if it fails. Alternately, I could encode the `&` for each invalid entity (where either of the digits is not `/[0-9a-f/i`, then re-decode the whole string.