### PR TITLE
Fix removing ? and # characters

### DIFF
--- a/can-deparam-test.js
+++ b/can-deparam-test.js
@@ -76,6 +76,13 @@ QUnit.test("takes value deserializer", function(assert) {
 	});
 });
 
+QUnit.test(" handle '?' and '#' ", function(assert) {
+	var result = deparam("?foo=bar&number=1234", stringToAny);
+	assert.deepEqual(result, {"foo" : "bar", "number": 1234});
+	result = deparam("#foo[]=bar&foo[]=baz");
+	assert.deepEqual(result, {"foo" : ["bar", "baz"]});
+});
+
 
 /** /
 test("deparam an array", function(){

--- a/can-deparam.js
+++ b/can-deparam.js
@@ -41,7 +41,7 @@ var digitTest = /^\d+$/,
 	keyBreaker = /([^\[\]]+)|(\[\])/g,
 	paramTest = /([^?#]*)(#.*)?$/,
 	entityRegex = /%([^0-9a-f][0-9a-f]|[0-9a-f][^0-9a-f]|[^0-9a-f][^0-9a-f])/i,
-    startChars = {"#": true,"?": true},
+	startChars = {"#": true,"?": true},
 	prep = function (str) {
 		if (startChars[str.charAt(0)] === true) {
 			str = str.substr(1, str.length);

--- a/can-deparam.js
+++ b/can-deparam.js
@@ -42,6 +42,9 @@ var digitTest = /^\d+$/,
 	paramTest = /([^?#]*)(#.*)?$/,
 	entityRegex = /%([^0-9a-f][0-9a-f]|[0-9a-f][^0-9a-f]|[^0-9a-f][^0-9a-f])/i,
 	prep = function (str) {
+		if (str.charAt(0) === "#" || str.charAt(0) === "?") {
+			str = str.substr(1, str.length);
+		}
 		str = str.replace(/\+/g, ' ');
 
 		try {

--- a/can-deparam.js
+++ b/can-deparam.js
@@ -41,8 +41,9 @@ var digitTest = /^\d+$/,
 	keyBreaker = /([^\[\]]+)|(\[\])/g,
 	paramTest = /([^?#]*)(#.*)?$/,
 	entityRegex = /%([^0-9a-f][0-9a-f]|[0-9a-f][^0-9a-f]|[^0-9a-f][^0-9a-f])/i,
+    startChars = {"#": true,"?": true},
 	prep = function (str) {
-		if (str.charAt(0) === "#" || str.charAt(0) === "?") {
+		if (startChars[str.charAt(0)] === true) {
 			str = str.substr(1, str.length);
 		}
 		str = str.replace(/\+/g, ' ');

--- a/can-deparam.js
+++ b/can-deparam.js
@@ -44,7 +44,7 @@ var digitTest = /^\d+$/,
 	startChars = {"#": true,"?": true},
 	prep = function (str) {
 		if (startChars[str.charAt(0)] === true) {
-			str = str.substr(1, str.length);
+			str = str.substr(1);
 		}
 		str = str.replace(/\+/g, ' ');
 


### PR DESCRIPTION
Fixes #17 

This removes `?` and `#` characters from parameters:
`deparam("?foo=bar&number=1234"); // -> {"foo" : "bar", "number": 1234}`
`deparam("#foo[]=bar&foo[]=baz"); // -> '{"foo" : ["bar", "baz"]}`

The fix checks if the first character is `?` or `#`with`str.charAt(0)` and removes it with `str.substr(1, str.length);`